### PR TITLE
Upgrade Node.js requirement and add strict conventional commit type check

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,21 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    uses: voxpelli/ghatemplates/.github/workflows/test.yml@main
+    with:
+      node-versions: '20,22,24,26'
+      os: 'ubuntu-latest,windows-latest'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,12 +6,12 @@ on:
       - main
 
 permissions:
-  contents: write
+  contents: read
   id-token: write
-  packages: write
-  pull-requests: write
 
 jobs:
   release-please:
-    uses: voxpelli/ghatemplates/.github/workflows/release-please-4.yml@main
+    uses: voxpelli/ghatemplates/.github/workflows/release-please-oidc.yml@main
     secrets: inherit
+    with:
+      app-id: '1082006'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Smallest simplest conventional commit validator to use with eg [`husky`](https:/
 npx --no validate-conventional-commit < .git/COMMIT_EDITMSG
 ```
 
+Add `--strict` to also require the commit type to be one of the exact conventional commit types (`build`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`), eg to catch `test:` vs `tests:` or `testing:`:
+
+```bash
+npx --no validate-conventional-commit --strict < .git/COMMIT_EDITMSG
+```
+
 (Or simply just copy and paste the [`cli.js`](cli.js) file into your project if you want to avoid a dependency)
 
 ## Related modules

--- a/cli.js
+++ b/cli.js
@@ -1,6 +1,24 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
+// The exact types of @commitlint/config-conventional, based on the Angular convention:
+// https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/config-conventional/src/index.ts
+const EXACT_COMMIT_TYPES = new Set([
+  'build',
+  'chore',
+  'ci',
+  'docs',
+  'feat',
+  'fix',
+  'perf',
+  'refactor',
+  'revert',
+  'style',
+  'test',
+]);
+
+const isStrict = process.argv.includes('--strict');
+
 let commitMessage = '';
 
 if (process.stdin.isTTY) {
@@ -20,7 +38,16 @@ if (commitMessage.trim() === '') {
 // eslint-disable-next-line regexp/no-unused-capturing-group
 const conventionalCommitMessage = /^(?<type>\w+)(?:\((?<scope>\w+)\))?(?<breaking>!?): (?<description>[^\n]+)/;
 
-if (!conventionalCommitMessage.test(commitMessage)) {
+const match = conventionalCommitMessage.exec(commitMessage);
+
+if (!match) {
   console.error('Invalid commit message, does not follow conventional commits');
+  process.exit(1);
+}
+
+const type = match.groups?.['type'] ?? '';
+
+if (isStrict && !EXACT_COMMIT_TYPES.has(type)) {
+  console.error(`Invalid commit type "${type}", expected one of: ${[...EXACT_COMMIT_TYPES].toSorted().join(', ')}`);
   process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Pelle Wessman <pelle@kodfabrik.se> (http://kodfabrik.se/)",
   "license": "0BSD",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.0.0"
   },
   "type": "module",
   "bin": {
@@ -28,19 +28,19 @@
     "cli.js"
   ],
   "scripts": {
+    "check": "run-p check:*",
     "check:lint": "eslint --report-unused-disable-directives .",
     "check:tsc": "tsc",
-    "check": "run-p check:*",
     "prepare": "husky",
     "test": "run-s check"
   },
   "devDependencies": {
-    "@types/node": "^16.18.123",
-    "@voxpelli/eslint-config": "^23.0.0",
-    "@voxpelli/tsconfig": "^15.1.0",
-    "eslint": "^9.28.0",
+    "@types/node": "^20.19.43",
+    "@voxpelli/eslint-config": "^25.1.0",
+    "@voxpelli/tsconfig": "^16.2.1",
+    "eslint": "^9.39.5",
     "husky": "^9.1.7",
-    "npm-run-all2": "^7.0.2",
-    "typescript": "~5.7.2"
+    "npm-run-all2": "^9.0.3",
+    "typescript": "~6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
   ],
   "scripts": {
     "check": "run-p check:*",
-    "check:lint": "eslint --report-unused-disable-directives .",
+    "check:lint": "eslint",
     "check:tsc": "tsc",
     "prepare": "husky",
-    "test": "run-s check"
+    "test": "run-s check test:*",
+    "test-ci": "run-s test:*",
+    "test:node": "node --test \"test/**/*.test.js\""
   },
   "devDependencies": {
     "@types/node": "^20.19.43",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepare": "husky",
     "test": "run-s check test:*",
     "test-ci": "run-s test:*",
-    "test:node": "node --test \"test/**/*.test.js\""
+    "test:node": "node --test test/cli.test.js"
   },
   "devDependencies": {
     "@types/node": "^20.19.43",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url));
+
+/**
+ * Runs the CLI with the given commit message on stdin
+ *
+ * @param {string} commitMessage - the commit message to validate
+ * @param {string[]} [args] - CLI arguments
+ * @returns {Promise<{ status: number | null, stderr: string }>} the exit status and stderr of the CLI
+ */
+function runCli (commitMessage, args = []) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (status) => {
+      resolve({ status, stderr });
+    });
+
+    child.stdin.end(commitMessage);
+  });
+}
+
+test('accepts a valid conventional commit message', async () => {
+  const result = await runCli('feat: add a new feature');
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stderr, '');
+});
+
+test('accepts a scope', async () => {
+  const result = await runCli('fix(core): fix a bug');
+
+  assert.equal(result.status, 0);
+});
+
+test('accepts a breaking change marker', async () => {
+  const result = await runCli('feat!: drop support for old versions');
+
+  assert.equal(result.status, 0);
+});
+
+test('accepts any type by default', async () => {
+  const result = await runCli('tests: some random type');
+
+  assert.equal(result.status, 0);
+});
+
+test('rejects a message without a conventional commit format', async () => {
+  const result = await runCli('this is not a conventional commit');
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid commit message/);
+});
+
+test('rejects an empty commit message', async () => {
+  const result = await runCli('\n\n');
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Empty commit message/);
+});
+
+test('accepts all the exact conventional commit types in strict mode', async () => {
+  const validTypes = ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'];
+
+  for (const type of validTypes) {
+    const result = await runCli(`${type}: a valid message`, ['--strict']);
+
+    assert.equal(result.status, 0, `expected ${type}: to be accepted`);
+    assert.equal(result.stderr, '', `expected ${type}: to pass without error`);
+  }
+});
+
+test('rejects a non-exact type in strict mode', async () => {
+  const result = await runCli('tests: not an exact type', ['--strict']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid commit type "tests"/);
+  assert.match(result.stderr, /expected one of:/);
+});
+
+test('rejects a pluralized type in strict mode', async () => {
+  const result = await runCli('testing: not an exact type', ['--strict']);
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Invalid commit type "testing"/);
+});
+
+test('accepts an exact type with scope and breaking marker in strict mode', async () => {
+  const result = await runCli('chore(deps)!: update dependencies', ['--strict']);
+
+  assert.equal(result.status, 0);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@voxpelli/tsconfig/node16.json",
+  "extends": "@voxpelli/tsconfig/node20.json",
   "files": [
     "cli.js"
   ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@voxpelli/tsconfig/node20.json",
   "files": [
-    "cli.js"
+    "cli.js",
+    "test/cli.test.js"
   ]
 }


### PR DESCRIPTION
Update the minimum supported Node.js version to 20.0.0 and switch the TypeScript configuration to the corresponding version. Introduce an optional `--strict` flag to enforce exact conventional commit types, improving validation by rejecting non-standard types.

Closes #21